### PR TITLE
Remove 'fs' and 'path' dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
   "dependencies": {
     "lazypipe": "1.0.1",
     "lodash": "4.6.1",
-    "fs": "0.0.2",
-    "gulp-add-src": "0.2.0",
-    "path": "0.12.7"
+    "gulp-add-src": "0.2.0"
   },
   "devDependencies": {
     "babel-core": "6.7.2",


### PR DESCRIPTION
Ref: http://npm.im/fs

Also, not sure if `gulp-add-src` should be a dependency vs devDependency. :shrug:
